### PR TITLE
Implement victory and defeat

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -10,6 +10,9 @@ pub struct Health {
     pub max: i32,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct ChasesPlayer;
+
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Name(pub String);
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,6 +2,9 @@ use bracket_lib::prelude::*;
 use legion::Entity;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct AmuletOfYala;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Enemy;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -12,6 +15,9 @@ pub struct Health {
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ChasesPlayer;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct Item;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Name(pub String);

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,46 @@ impl State {
             player_systems: build_player_turn_scheduler(),
         }
     }
+
+    fn game_over(&mut self, ctx: &mut BTerm) {
+        ctx.set_active_console(HUD_LAYER);
+
+        ctx.print_color_centered(2, RED, BLACK, "Your quest has ended.");
+        ctx.print_color_centered(
+            4,
+            WHITE,
+            BLACK,
+            "Slain by a monster, your hero's journey has come to a premature end",
+        );
+        ctx.print_color_centered(
+            5,
+            WHITE,
+            BLACK,
+            "The Amulet of Yala remains unclaimed, and your home town is not saved.",
+        );
+        ctx.print_color_centered(
+            8,
+            YELLOW,
+            BLACK,
+            "Don't worry, you can always try again with a new hero.",
+        );
+        ctx.print_color_centered(9, GREEN, BLACK, "Press SPACE to play again.");
+
+        if let Some(VirtualKeyCode::Space) = ctx.key {
+            self.ecs = World::default();
+
+            let mut rng = RandomNumberGenerator::new();
+            let map_builder = MapBuilder::new(&mut rng);
+
+            self.resources = Resources::default();
+            self.resources.insert(map_builder.map);
+            self.resources.insert(Camera::new(map_builder.player_start));
+            self.resources.insert(TurnState::AwaitingInput);
+
+            spawn_player(&mut self.ecs, map_builder.player_start);
+            spawn_monsters(&mut self.ecs, &mut rng, map_builder.rooms);
+        }
+    }
 }
 
 impl GameState for State {
@@ -76,12 +116,20 @@ impl GameState for State {
         ctx.set_active_console(MAP_LAYER);
         self.resources.insert(Point::from_tuple(ctx.mouse_pos()));
 
-        let system = match *self.resources.get::<TurnState>().unwrap() {
-            TurnState::AwaitingInput => &mut self.input_systems,
-            TurnState::PlayerTurn => &mut self.player_systems,
-            TurnState::MonsterTurn => &mut self.monster_systems,
+        let turn_state = *self.resources.get::<TurnState>().unwrap();
+
+        match turn_state {
+            TurnState::AwaitingInput => self
+                .input_systems
+                .execute(&mut self.ecs, &mut self.resources),
+            TurnState::PlayerTurn => self
+                .player_systems
+                .execute(&mut self.ecs, &mut self.resources),
+            TurnState::MonsterTurn => self
+                .monster_systems
+                .execute(&mut self.ecs, &mut self.resources),
+            TurnState::GameOver => self.game_over(ctx),
         };
-        system.execute(&mut self.ecs, &mut self.resources);
 
         render_draw_buffer(ctx).expect("failed to render draw buffer");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ impl State {
         }
     }
 
-    fn game_over(&mut self, ctx: &mut BTerm) {
+    fn defeat(&mut self, ctx: &mut BTerm) {
         ctx.set_active_console(HUD_LAYER);
 
         ctx.print_color_centered(2, RED, BLACK, "Your quest has ended.");
@@ -85,20 +85,47 @@ impl State {
         ctx.print_color_centered(9, GREEN, BLACK, "Press SPACE to play again.");
 
         if let Some(VirtualKeyCode::Space) = ctx.key {
-            self.ecs = World::default();
-
-            let mut rng = RandomNumberGenerator::new();
-            let map_builder = MapBuilder::new(&mut rng);
-
-            self.resources = Resources::default();
-            self.resources.insert(map_builder.map);
-            self.resources.insert(Camera::new(map_builder.player_start));
-            self.resources.insert(TurnState::AwaitingInput);
-
-            spawn_amulet_of_yala(&mut self.ecs, map_builder.amulet_position);
-            spawn_player(&mut self.ecs, map_builder.player_start);
-            spawn_monsters(&mut self.ecs, &mut rng, map_builder.rooms);
+            self.reset_game_state();
         }
+    }
+
+    fn victory(&mut self, ctx: &mut BTerm) {
+        ctx.set_active_console(HUD_LAYER);
+
+        ctx.print_color_centered(2, GREEN, BLACK, "You have won!");
+        ctx.print_color_centered(
+            4,
+            WHITE,
+            BLACK,
+            "You put on the Amulet of Yala and feel ist power course through your veins.",
+        );
+        ctx.print_color_centered(
+            5,
+            WHITE,
+            BLACK,
+            "Your town is saved, and you can return to a normal life.",
+        );
+        ctx.print_color_centered(7, GREEN, BLACK, "Press SPACE to play again.");
+
+        if let Some(VirtualKeyCode::Space) = ctx.key {
+            self.reset_game_state();
+        }
+    }
+
+    fn reset_game_state(&mut self) {
+        self.ecs = World::default();
+
+        let mut rng = RandomNumberGenerator::new();
+        let map_builder = MapBuilder::new(&mut rng);
+
+        self.resources = Resources::default();
+        self.resources.insert(map_builder.map);
+        self.resources.insert(Camera::new(map_builder.player_start));
+        self.resources.insert(TurnState::AwaitingInput);
+
+        spawn_amulet_of_yala(&mut self.ecs, map_builder.amulet_position);
+        spawn_player(&mut self.ecs, map_builder.player_start);
+        spawn_monsters(&mut self.ecs, &mut rng, map_builder.rooms);
     }
 }
 
@@ -130,7 +157,8 @@ impl GameState for State {
             TurnState::MonsterTurn => self
                 .monster_systems
                 .execute(&mut self.ecs, &mut self.resources),
-            TurnState::Defeat => self.game_over(ctx),
+            TurnState::Defeat => self.defeat(ctx),
+            TurnState::Victory => self.victory(ctx),
         };
 
         render_draw_buffer(ctx).expect("failed to render draw buffer");

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ impl GameState for State {
             TurnState::MonsterTurn => self
                 .monster_systems
                 .execute(&mut self.ecs, &mut self.resources),
-            TurnState::GameOver => self.game_over(ctx),
+            TurnState::Defeat => self.game_over(ctx),
         };
 
         render_draw_buffer(ctx).expect("failed to render draw buffer");

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use legion::{Resources, Schedule, World};
 use crate::camera::Camera;
 use crate::map::{Map, MAP_HEIGHT, MAP_WIDTH};
 use crate::map_builder::MapBuilder;
-use crate::spawner::{spawn_monster, spawn_player};
+use crate::spawner::{spawn_amulet_of_yala, spawn_monster, spawn_player};
 use crate::systems::{
     build_input_scheduler, build_monster_turn_scheduler, build_player_turn_scheduler,
 };
@@ -47,6 +47,7 @@ impl State {
         resources.insert(Camera::new(map_builder.player_start));
         resources.insert(TurnState::AwaitingInput);
 
+        spawn_amulet_of_yala(&mut ecs, map_builder.amulet_position);
         spawn_player(&mut ecs, map_builder.player_start);
         spawn_monsters(&mut ecs, &mut rng, map_builder.rooms);
 
@@ -94,6 +95,7 @@ impl State {
             self.resources.insert(Camera::new(map_builder.player_start));
             self.resources.insert(TurnState::AwaitingInput);
 
+            spawn_amulet_of_yala(&mut self.ecs, map_builder.amulet_position);
             spawn_player(&mut self.ecs, map_builder.player_start);
             spawn_monsters(&mut self.ecs, &mut rng, map_builder.rooms);
         }

--- a/src/map.rs
+++ b/src/map.rs
@@ -24,6 +24,59 @@ impl Map {
     pub fn is_enterable_tile(&self, point: Point) -> bool {
         point_within_bounds(point) && self.tiles[point_to_index(point)] == TileType::Floor
     }
+
+    pub fn is_valid_step(&self, position: Point, delta: Point) -> Option<usize> {
+        let destination = position + delta;
+
+        if point_within_bounds(destination) && self.is_enterable_tile(destination) {
+            let index = point_to_index(destination);
+            Some(index)
+        } else {
+            None
+        }
+    }
+}
+
+impl Algorithm2D for Map {
+    fn dimensions(&self) -> Point {
+        Point::new(MAP_WIDTH, MAP_HEIGHT)
+    }
+
+    fn in_bounds(&self, point: Point) -> bool {
+        point_within_bounds(point)
+    }
+}
+
+impl BaseMap for Map {
+    fn get_available_exits(&self, index: usize) -> SmallVec<[(usize, f32); 10]> {
+        let mut exits = SmallVec::new();
+        let position = self.index_to_point2d(index);
+
+        if let Some(index) = self.is_valid_step(position, Point::new(-1, 0)) {
+            exits.push((index, 1.0));
+        }
+
+        if let Some(index) = self.is_valid_step(position, Point::new(1, 0)) {
+            exits.push((index, 1.0));
+        }
+
+        if let Some(index) = self.is_valid_step(position, Point::new(0, -1)) {
+            exits.push((index, 1.0));
+        }
+
+        if let Some(index) = self.is_valid_step(position, Point::new(0, 1)) {
+            exits.push((index, 1.0));
+        }
+
+        exits
+    }
+
+    fn get_pathing_distance(&self, start: usize, destination: usize) -> f32 {
+        DistanceAlg::Pythagoras.distance2d(
+            self.index_to_point2d(start),
+            self.index_to_point2d(destination),
+        )
+    }
 }
 
 pub fn coordinate_to_index(x: i32, y: i32) -> usize {

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -1,7 +1,7 @@
 use bracket_lib::prelude::*;
 use legion::World;
 
-use crate::components::{ChasesPlayer, Enemy, Health, Name, Player, Render};
+use crate::components::{AmuletOfYala, ChasesPlayer, Enemy, Health, Item, Name, Player, Render};
 
 type Monster = (i32, String, FontCharType);
 
@@ -11,6 +11,19 @@ fn goblin() -> Monster {
 
 fn orc() -> Monster {
     (2, "Orc".to_string(), to_cp437('o'))
+}
+
+pub fn spawn_amulet_of_yala(ecs: &mut World, position: Point) {
+    ecs.push((
+        AmuletOfYala,
+        Item,
+        Name("Amulet of Yala".to_string()),
+        position,
+        Render {
+            color: ColorPair::new(WHITE, BLACK),
+            glyph: to_cp437('|'),
+        },
+    ));
 }
 
 pub fn spawn_monster(ecs: &mut World, rng: &mut RandomNumberGenerator, position: Point) {

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -39,8 +39,8 @@ pub fn spawn_player(ecs: &mut World, position: Point) {
     ecs.push((
         Player,
         Health {
-            current: 20,
-            max: 20,
+            current: 10,
+            max: 10,
         },
         position,
         Render {

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -1,7 +1,7 @@
 use bracket_lib::prelude::*;
 use legion::World;
 
-use crate::components::{Enemy, Health, Name, Player, RandomMovement, Render};
+use crate::components::{ChasesPlayer, Enemy, Health, Name, Player, Render};
 
 type Monster = (i32, String, FontCharType);
 
@@ -21,13 +21,13 @@ pub fn spawn_monster(ecs: &mut World, rng: &mut RandomNumberGenerator, position:
 
     ecs.push((
         Enemy,
+        ChasesPlayer,
         Health {
             current: hp,
             max: hp,
         },
         Name(name),
         position,
-        RandomMovement,
         Render {
             color: ColorPair::new(WHITE, BLACK),
             glyph,

--- a/src/systems/chase_player.rs
+++ b/src/systems/chase_player.rs
@@ -1,0 +1,52 @@
+use bracket_lib::prelude::*;
+use legion::systems::CommandBuffer;
+use legion::world::SubWorld;
+use legion::{system, Entity, IntoQuery};
+
+use crate::components::{ChasesPlayer, Health, Player, WantsToAttack, WantsToMove};
+use crate::map::point_to_index;
+use crate::{Map, MAP_HEIGHT, MAP_WIDTH};
+
+#[system]
+#[read_component(ChasesPlayer)]
+#[read_component(Health)]
+#[read_component(Player)]
+#[read_component(Point)]
+pub fn chase_player(ecs: &SubWorld, commands: &mut CommandBuffer, #[resource] map: &Map) {
+    let mut chasing_monsters = <(Entity, &Point, &ChasesPlayer)>::query();
+    let mut player = <(Entity, &Point, &Player)>::query();
+
+    let (player_entity, player_position, _) = player.iter(ecs).next().unwrap();
+    let player_index = point_to_index(*player_position);
+
+    let search_targets = vec![player_index];
+    let dijkstra_map = DijkstraMap::new(MAP_WIDTH, MAP_HEIGHT, &search_targets, map, 1024.0);
+
+    chasing_monsters
+        .iter(ecs)
+        .for_each(|(entity, position, _)| {
+            let index = point_to_index(*position);
+
+            if let Some(destination) = DijkstraMap::find_lowest_exit(&dijkstra_map, index, map) {
+                let distance = DistanceAlg::Pythagoras.distance2d(*position, *player_position);
+
+                if distance > 1.2 {
+                    commands.push((
+                        (),
+                        WantsToMove {
+                            entity: *entity,
+                            destination: map.index_to_point2d(destination),
+                        },
+                    ));
+                } else {
+                    commands.push((
+                        (),
+                        WantsToAttack {
+                            attacker: *entity,
+                            victim: *player_entity,
+                        },
+                    ));
+                };
+            }
+        });
+}

--- a/src/systems/combat.rs
+++ b/src/systems/combat.rs
@@ -2,9 +2,10 @@ use legion::systems::CommandBuffer;
 use legion::world::SubWorld;
 use legion::{system, Entity, EntityStore, IntoQuery};
 
-use crate::components::{Health, WantsToAttack};
+use crate::components::{Health, Player, WantsToAttack};
 
 #[system]
+#[read_component(Player)]
 #[read_component(WantsToAttack)]
 #[write_component(Health)]
 pub fn combat(ecs: &mut SubWorld, commands: &mut CommandBuffer) {
@@ -14,6 +15,12 @@ pub fn combat(ecs: &mut SubWorld, commands: &mut CommandBuffer) {
         .collect();
 
     victims.iter().for_each(|(message, victim)| {
+        let is_player = ecs
+            .entry_ref(*victim)
+            .unwrap()
+            .get_component::<Player>()
+            .is_ok();
+
         if let Ok(mut health) = ecs
             .entry_mut(*victim)
             .unwrap()
@@ -21,7 +28,7 @@ pub fn combat(ecs: &mut SubWorld, commands: &mut CommandBuffer) {
         {
             health.current -= 1;
 
-            if health.current < 1 {
+            if health.current < 1 && !is_player {
                 commands.remove(*victim);
             }
         }

--- a/src/systems/end_turn.rs
+++ b/src/systems/end_turn.rs
@@ -1,14 +1,18 @@
+use bracket_lib::prelude::*;
 use legion::world::SubWorld;
 use legion::{component, system, IntoQuery};
 
-use crate::components::{Health, Player};
+use crate::components::{AmuletOfYala, Health, Player};
 use crate::TurnState;
 
 #[system]
+#[read_component(AmuletOfYala)]
 #[read_component(Health)]
 #[read_component(Player)]
+#[read_component(Point)]
 pub fn end_turn(ecs: &SubWorld, #[resource] turn_state: &mut TurnState) {
-    let mut player_health = <&Health>::query().filter(component::<Player>());
+    let mut player = <(&Health, &Point)>::query().filter(component::<Player>());
+    let mut amulet = <&Point>::query().filter(component::<AmuletOfYala>());
 
     let mut next_state = match turn_state {
         TurnState::AwaitingInput => return,
@@ -17,9 +21,14 @@ pub fn end_turn(ecs: &SubWorld, #[resource] turn_state: &mut TurnState) {
         _ => *turn_state,
     };
 
-    player_health.iter(ecs).for_each(|health| {
+    let amulet_position = amulet.iter(ecs).next().unwrap();
+
+    player.iter(ecs).for_each(|(health, position)| {
         if health.current < 1 {
-            next_state = TurnState::GameOver;
+            next_state = TurnState::Defeat;
+        }
+        if position == amulet_position {
+            next_state = TurnState::Victory;
         }
     });
 

--- a/src/systems/end_turn.rs
+++ b/src/systems/end_turn.rs
@@ -1,14 +1,27 @@
-use legion::system;
+use legion::world::SubWorld;
+use legion::{component, system, IntoQuery};
 
+use crate::components::{Health, Player};
 use crate::TurnState;
 
 #[system]
-pub fn end_turn(#[resource] turn_state: &mut TurnState) {
-    let next_state = match turn_state {
+#[read_component(Health)]
+#[read_component(Player)]
+pub fn end_turn(ecs: &SubWorld, #[resource] turn_state: &mut TurnState) {
+    let mut player_health = <&Health>::query().filter(component::<Player>());
+
+    let mut next_state = match turn_state {
+        TurnState::AwaitingInput => return,
         TurnState::PlayerTurn => TurnState::MonsterTurn,
         TurnState::MonsterTurn => TurnState::AwaitingInput,
-        TurnState::AwaitingInput => return,
+        _ => *turn_state,
     };
+
+    player_health.iter(ecs).for_each(|health| {
+        if health.current < 1 {
+            next_state = TurnState::GameOver;
+        }
+    });
 
     *turn_state = next_state;
 }

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -1,5 +1,6 @@
 use legion::Schedule;
 
+mod chase_player;
 mod combat;
 mod end_turn;
 mod move_entity;
@@ -24,6 +25,7 @@ pub fn build_input_scheduler() -> Schedule {
 pub fn build_monster_turn_scheduler() -> Schedule {
     Schedule::builder()
         .add_system(move_randomly::move_randomly_system())
+        .add_system(chase_player::chase_player_system())
         .flush()
         .add_system(combat::combat_system())
         .flush()

--- a/src/turn_state.rs
+++ b/src/turn_state.rs
@@ -3,5 +3,6 @@ pub enum TurnState {
     AwaitingInput,
     PlayerTurn,
     MonsterTurn,
-    GameOver,
+    Defeat,
+    Victory,
 }

--- a/src/turn_state.rs
+++ b/src/turn_state.rs
@@ -1,6 +1,7 @@
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum TurnState {
     AwaitingInput,
-    MonsterTurn,
     PlayerTurn,
+    MonsterTurn,
+    GameOver,
 }


### PR DESCRIPTION
The game can now be won or lost. If the player loses all their health,
they die and have to restart. They can win the game by picking up the
Amulet of Yala, which is spawned as an item in the dungeon. Both the
victory and defeat states have their own screen, which informs the
player of the outcome and offers them to restart the game.

https://user-images.githubusercontent.com/865550/156005088-e8bd4555-d76b-4899-8cda-8dbd2baa9fa6.mov



