### PR TITLE
Add field of view

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -1,11 +1,37 @@
 use bracket_lib::prelude::*;
 use legion::Entity;
+use std::collections::HashSet;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct AmuletOfYala;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Enemy;
+
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct FieldOfView {
+    pub visible_tiles: HashSet<Point>,
+    pub radius: i32,
+    pub is_dirty: bool,
+}
+
+impl FieldOfView {
+    pub fn new(radius: i32) -> Self {
+        Self {
+            visible_tiles: HashSet::new(),
+            radius,
+            is_dirty: false,
+        }
+    }
+
+    pub fn clone_dirty(&self) -> Self {
+        Self {
+            visible_tiles: HashSet::new(),
+            radius: self.radius,
+            is_dirty: true,
+        }
+    }
+}
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Health {

--- a/src/components.rs
+++ b/src/components.rs
@@ -20,7 +20,7 @@ impl FieldOfView {
         Self {
             visible_tiles: HashSet::new(),
             radius,
-            is_dirty: false,
+            is_dirty: true,
         }
     }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -48,6 +48,10 @@ impl Algorithm2D for Map {
 }
 
 impl BaseMap for Map {
+    fn is_opaque(&self, index: usize) -> bool {
+        self.tiles[index] != TileType::Floor
+    }
+
     fn get_available_exits(&self, index: usize) -> SmallVec<[(usize, f32); 10]> {
         let mut exits = SmallVec::new();
         let position = self.index_to_point2d(index);

--- a/src/map.rs
+++ b/src/map.rs
@@ -12,12 +12,14 @@ pub enum TileType {
 
 pub struct Map {
     pub tiles: Vec<TileType>,
+    pub revealed_tiles: Vec<bool>,
 }
 
 impl Map {
     pub fn new() -> Self {
         Self {
             tiles: vec![TileType::Floor; NUM_TILES],
+            revealed_tiles: vec![false; NUM_TILES],
         }
     }
 

--- a/src/spawner.rs
+++ b/src/spawner.rs
@@ -1,7 +1,9 @@
 use bracket_lib::prelude::*;
 use legion::World;
 
-use crate::components::{AmuletOfYala, ChasesPlayer, Enemy, Health, Item, Name, Player, Render};
+use crate::components::{
+    AmuletOfYala, ChasesPlayer, Enemy, FieldOfView, Health, Item, Name, Player, Render,
+};
 
 type Monster = (i32, String, FontCharType);
 
@@ -35,6 +37,7 @@ pub fn spawn_monster(ecs: &mut World, rng: &mut RandomNumberGenerator, position:
     ecs.push((
         Enemy,
         ChasesPlayer,
+        FieldOfView::new(6),
         Health {
             current: hp,
             max: hp,
@@ -51,6 +54,7 @@ pub fn spawn_monster(ecs: &mut World, rng: &mut RandomNumberGenerator, position:
 pub fn spawn_player(ecs: &mut World, position: Point) {
     ecs.push((
         Player,
+        FieldOfView::new(8),
         Health {
             current: 10,
             max: 10,

--- a/src/systems/fov.rs
+++ b/src/systems/fov.rs
@@ -1,0 +1,19 @@
+use bracket_lib::prelude::*;
+use legion::world::SubWorld;
+use legion::{system, IntoQuery};
+
+use crate::components::FieldOfView;
+use crate::Map;
+
+#[system]
+#[read_component(Point)]
+#[write_component(FieldOfView)]
+pub fn field_of_view(ecs: &mut SubWorld, #[resource] map: &Map) {
+    <(&Point, &mut FieldOfView)>::query()
+        .iter_mut(ecs)
+        .filter(|(_, fov)| fov.is_dirty)
+        .for_each(|(position, mut fov)| {
+            fov.visible_tiles = field_of_view_set(*position, fov.radius, map);
+            fov.is_dirty = false;
+        });
+}

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -3,6 +3,7 @@ use legion::Schedule;
 mod chase_player;
 mod combat;
 mod end_turn;
+mod fov;
 mod move_entity;
 mod move_randomly;
 mod process_input;
@@ -31,6 +32,8 @@ pub fn build_monster_turn_scheduler() -> Schedule {
         .flush()
         .add_system(move_entity::move_entity_system())
         .flush()
+        .add_system(fov::field_of_view_system())
+        .flush()
         .add_system(render_entity::render_entity_system())
         .add_system(render_map::render_map_system())
         .add_system(render_hud::render_hud_system())
@@ -43,6 +46,8 @@ pub fn build_player_turn_scheduler() -> Schedule {
         .add_system(combat::combat_system())
         .flush()
         .add_system(move_entity::move_entity_system())
+        .flush()
+        .add_system(fov::field_of_view_system())
         .flush()
         .add_system(render_entity::render_entity_system())
         .add_system(render_map::render_map_system())

--- a/src/systems/mod.rs
+++ b/src/systems/mod.rs
@@ -15,6 +15,7 @@ mod render_tooltip;
 pub fn build_input_scheduler() -> Schedule {
     Schedule::builder()
         .add_system(process_input::process_input_system())
+        .add_system(fov::field_of_view_system())
         .flush()
         .add_system(render_entity::render_entity_system())
         .add_system(render_map::render_map_system())

--- a/src/systems/move_entity.rs
+++ b/src/systems/move_entity.rs
@@ -4,6 +4,7 @@ use legion::{system, Entity, EntityStore};
 
 use crate::components::WantsToMove;
 use crate::components::{FieldOfView, Player};
+use crate::map::point_to_index;
 use crate::{Camera, Map};
 
 #[system(for_each)]
@@ -14,7 +15,7 @@ pub fn move_entity(
     commands: &mut CommandBuffer,
     entity: &Entity,
     want_move: &WantsToMove,
-    #[resource] map: &Map,
+    #[resource] map: &mut Map,
     #[resource] camera: &mut Camera,
 ) {
     if map.is_enterable_tile(want_move.destination) {
@@ -23,9 +24,13 @@ pub fn move_entity(
         if let Ok(entry) = ecs.entry_ref(want_move.entity) {
             if let Ok(fov) = entry.get_component::<FieldOfView>() {
                 commands.add_component(want_move.entity, fov.clone_dirty());
-            }
-            if entry.get_component::<Player>().is_ok() {
-                camera.on_player_move(want_move.destination);
+
+                if entry.get_component::<Player>().is_ok() {
+                    camera.on_player_move(want_move.destination);
+                    fov.visible_tiles.iter().for_each(|position| {
+                        map.revealed_tiles[point_to_index(*position)] = true;
+                    })
+                }
             }
         }
     }

--- a/src/systems/move_entity.rs
+++ b/src/systems/move_entity.rs
@@ -2,11 +2,12 @@ use legion::systems::CommandBuffer;
 use legion::world::SubWorld;
 use legion::{system, Entity, EntityStore};
 
-use crate::components::Player;
 use crate::components::WantsToMove;
+use crate::components::{FieldOfView, Player};
 use crate::{Camera, Map};
 
 #[system(for_each)]
+#[read_component(FieldOfView)]
 #[read_component(Player)]
 pub fn move_entity(
     ecs: &SubWorld,
@@ -19,14 +20,15 @@ pub fn move_entity(
     if map.is_enterable_tile(want_move.destination) {
         commands.add_component(want_move.entity, want_move.destination);
 
-        if ecs
-            .entry_ref(want_move.entity)
-            .unwrap()
-            .get_component::<Player>()
-            .is_ok()
-        {
-            camera.on_player_move(want_move.destination);
+        if let Ok(entry) = ecs.entry_ref(want_move.entity) {
+            if let Ok(fov) = entry.get_component::<FieldOfView>() {
+                commands.add_component(want_move.entity, fov.clone_dirty());
+            }
+            if entry.get_component::<Player>().is_ok() {
+                camera.on_player_move(want_move.destination);
+            }
         }
     }
+
     commands.remove(*entity);
 }

--- a/src/systems/render_entity.rs
+++ b/src/systems/render_entity.rs
@@ -1,22 +1,31 @@
 use bracket_lib::prelude::*;
 use legion::world::SubWorld;
-use legion::{system, IntoQuery};
+use legion::{component, system, IntoQuery};
 
-use crate::components::Render;
+use crate::components::{FieldOfView, Player, Render};
 use crate::map::NUM_TILES;
 use crate::{Camera, ENTITY_LAYER};
 
 #[system]
+#[read_component(FieldOfView)]
+#[read_component(Player)]
 #[read_component(Point)]
 #[read_component(Render)]
 pub fn render_entity(ecs: &SubWorld, #[resource] camera: &Camera) {
     let mut draw_batch = DrawBatch::new();
     draw_batch.target(ENTITY_LAYER);
 
+    let fov = <&FieldOfView>::query()
+        .filter(component::<Player>())
+        .iter(ecs)
+        .next()
+        .unwrap();
+
     let offset = Point::new(camera.viewport.x1, camera.viewport.y1);
 
     <(&Point, &Render)>::query()
         .iter(ecs)
+        .filter(|(position, _)| fov.visible_tiles.contains(position))
         .for_each(|(position, render)| {
             draw_batch.set(*position - offset, render.color, render.glyph);
         });

--- a/src/systems/render_map.rs
+++ b/src/systems/render_map.rs
@@ -1,20 +1,30 @@
 use bracket_lib::prelude::*;
-use legion::system;
+use legion::world::SubWorld;
+use legion::{component, system, IntoQuery};
 
+use crate::components::{FieldOfView, Player};
 use crate::map::{point_to_index, point_within_bounds, TileType};
 use crate::{Camera, Map, MAP_LAYER};
 
 #[system]
-pub fn render_map(#[resource] map: &Map, #[resource] camera: &Camera) {
+#[read_component(FieldOfView)]
+#[read_component(Player)]
+pub fn render_map(ecs: &SubWorld, #[resource] map: &Map, #[resource] camera: &Camera) {
     let mut draw_batch = DrawBatch::new();
     draw_batch.target(MAP_LAYER);
+
+    let fov = <&FieldOfView>::query()
+        .filter(component::<Player>())
+        .iter(ecs)
+        .next()
+        .unwrap();
 
     for y in camera.viewport.y1..=camera.viewport.y2 {
         for x in camera.viewport.x1..=camera.viewport.x2 {
             let point = Point::new(x, y);
             let offset = Point::new(camera.viewport.x1, camera.viewport.y1);
 
-            if point_within_bounds(point) {
+            if point_within_bounds(point) && fov.visible_tiles.contains(&point) {
                 let index = point_to_index(point);
                 let glyph = match map.tiles[index] {
                     TileType::Floor => to_cp437('.'),

--- a/src/systems/render_map.rs
+++ b/src/systems/render_map.rs
@@ -24,14 +24,23 @@ pub fn render_map(ecs: &SubWorld, #[resource] map: &Map, #[resource] camera: &Ca
             let point = Point::new(x, y);
             let offset = Point::new(camera.viewport.x1, camera.viewport.y1);
 
-            if point_within_bounds(point) && fov.visible_tiles.contains(&point) {
-                let index = point_to_index(point);
+            let index = point_to_index(point);
+
+            if point_within_bounds(point)
+                && (fov.visible_tiles.contains(&point) || map.revealed_tiles[index])
+            {
+                let tint = if fov.visible_tiles.contains(&point) {
+                    WHITE
+                } else {
+                    DARK_GRAY
+                };
+
                 let glyph = match map.tiles[index] {
                     TileType::Floor => to_cp437('.'),
                     TileType::Wall => to_cp437('#'),
                 };
 
-                draw_batch.set(point - offset, ColorPair::new(WHITE, BLACK), glyph);
+                draw_batch.set(point - offset, ColorPair::new(tint, BLACK), glyph);
             }
         }
     }

--- a/src/systems/render_tooltip.rs
+++ b/src/systems/render_tooltip.rs
@@ -1,14 +1,16 @@
 use bracket_lib::prelude::*;
 use legion::world::SubWorld;
-use legion::{system, Entity, EntityStore, IntoQuery};
+use legion::{component, system, Entity, EntityStore, IntoQuery};
 
-use crate::components::{Health, Name};
+use crate::components::{FieldOfView, Health, Name, Player};
 use crate::map::NUM_TILES;
 use crate::{Camera, HUD_LAYER};
 
 #[system]
+#[read_component(FieldOfView)]
 #[read_component(Health)]
 #[read_component(Name)]
+#[read_component(Player)]
 #[read_component(Point)]
 pub fn render_tooltip(
     ecs: &SubWorld,
@@ -21,9 +23,17 @@ pub fn render_tooltip(
     let mut draw_batch = DrawBatch::new();
     draw_batch.target(HUD_LAYER);
 
+    let fov = <&FieldOfView>::query()
+        .filter(component::<Player>())
+        .iter(ecs)
+        .next()
+        .unwrap();
+
     <(Entity, &Point, &Name)>::query()
         .iter(ecs)
-        .filter(|(_, position, _)| **position == map_position)
+        .filter(|(_, position, _)| {
+            **position == map_position && fov.visible_tiles.contains(position)
+        })
         .for_each(|(entity, _, name)| {
             let screen_position = *mouse_position * 4;
             let display_string =


### PR DESCRIPTION
The rendering pipeline has been updated to take the entity's field of
view into consideration. The player can only see tiles in a certain
radius and within their line of sight, and monsters will only attack a
player if they can see them.

Tiles that a player has previously seen, but that are now outside of
their view, are rendered in gray.

![Screenshot 2022-02-28 at 17 32 06](https://user-images.githubusercontent.com/865550/156020886-06ecc0ba-332d-4a43-a8ff-b19937a9456e.png)
